### PR TITLE
Fixed JAX ImportError for deprecated/removed KeyArray

### DIFF
--- a/spacetime.py
+++ b/spacetime.py
@@ -1,0 +1,252 @@
+from typing import Callable
+
+from dataclasses import dataclass
+from anndata import AnnData
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from flax.training import orbax_utils
+from flax.training.early_stopping import EarlyStopping
+from jax.random import PRNGKey
+from jax import Array
+import uuid
+from orbax.checkpoint.args import StandardRestore
+from optax import GradientTransformation
+from orbax.checkpoint import CheckpointManager
+from orbax.checkpoint.args import StandardSave
+from tqdm import tqdm
+
+from .steps.proximal_step import ProximalStep
+from .steps.explicit import ExplicitStep
+from .potentials import MLPPotential
+from .tools import DataLoader, default_checkpoint_manager
+from .loss import loss_fn
+
+
+@dataclass
+class SpaceTime:
+    """Wasserstein gradient flow model for spatio-temporal omics data.
+
+    Args:
+        potential (nn.Module, optional): The potential function. Defaults to a MLP.
+        proximal_step (ProximalStep, optional): The proximal step. Defaults forward Euler
+        n_steps (int, optional): The number of steps. Defaults to 1.
+        teacher_forcing (bool, optional): Use teacher forcing. Defaults to True.
+        quadratic (bool, optional): Use a Fused GW loss. Defaults to True.
+        debias (bool, optional): Whether to debias the loss. Defaults to True.
+        epsilon (float, optional): The (relative) entropic reg. Defaults to 0.01.
+        log_callback (Callable, optional): The callback for logging. Defaults to None.
+        quadratic_weight (float, optional): Weight of the quadratic term, in [0, 1].
+    """
+
+    potential: nn.Module = MLPPotential()
+    proximal_step: ProximalStep = ExplicitStep()
+    n_steps: int = 1
+    teacher_forcing: bool = True
+    quadratic: bool = True
+    debias: bool = True
+    epsilon: float = 0.01
+    log_callback: Callable | None = None
+    quadratic_weight: float = 5e-3
+
+    def fit(
+        self,
+        adata: AnnData,
+        time_key: str,
+        omics_key: str,
+        space_key: str,
+        weight_key: str | None = None,
+        optimizer: GradientTransformation = optax.adamw(1e-2),
+        max_iter: int = 10_000,
+        batch_size: int = 1_000,
+        train_val_split: float = 0.75,
+        min_delta: float = 0.0,
+        patience: int = 150,
+        checkpoint_manager: CheckpointManager | str | None = None,
+        key: Array = PRNGKey(0),
+        restore: bool = True,
+    ) -> None:
+        """Fit the model.
+
+        Args:
+            adata (AnnData): The AnnData object.
+            time_key (str): The name of the time observation.
+            omics_key (str): The name of the obsm field containing cell coordinates.
+            space_key (str): The name of the obsm field containing space coordinates.
+            weight_key (str): The name of the obs field containing weights.
+            optimizer (GradientTransformation, optional): The optimizer.
+            max_iter (int, optional): The max number of iterations. Defaults to 10_000.
+            batch_size (int, optional): The batch size. Defaults to 1_000.
+            train_val_split (float, optional): The proportion of train in the split.
+            min_delta (float, optional): The minimum delta for early stopping.
+            patience (int, optional): The patience for early stopping.
+            checkpoint_manager (CheckpointManager, optional): Checkpoint manager or path.
+            key (KeyArray, optional): The random key. Defaults to PRNGKey(0).
+            restore (bool, optional): By default, load the checkpointed params.
+        """
+
+        # Assert the quadratic weight is strictly between 0 and 1 if self.quadratic.
+        if self.quadratic:
+            assert (
+                0 < self.quadratic_weight < 1
+            ), "Relative quadratic weight must be strictly between 0 and 1."
+
+        # If the checkpoint_manager is a string, make the default one.
+        if not checkpoint_manager:
+            checkpoint_manager = default_checkpoint_manager(f"/tmp/{uuid.uuid4()}")
+        elif checkpoint_manager and isinstance(checkpoint_manager, str):
+            checkpoint_manager = default_checkpoint_manager(checkpoint_manager)
+
+        # Initialize the statistics for logging.
+        self.train_it, self.train_losses = [], []
+        self.val_it, self.val_losses = [], []
+
+        # Create a data loader for the AnnData object.
+        dataloader = DataLoader(
+            adata,
+            time_key=time_key,
+            omics_key=omics_key,
+            space_key=space_key,
+            weight_key=weight_key,
+            batch_size=batch_size,
+            train_val_split=train_val_split,
+        )
+
+        # Split the cells ids into train and validation.
+        split_key, key = jax.random.split(key)
+        dataloader.make_train_val_split(split_key)
+
+        # Compute tau from the timepoints.
+        tau_diff = jnp.array(np.diff(dataloader.timepoints).astype(float))
+
+        # Define some arguments shared by the train and validation loss.
+        lkwargs = {"teacher_forcing": self.teacher_forcing, "potential": self.potential}
+        lkwargs = {**lkwargs, "quadratic": self.quadratic, "debias": self.debias}
+        lkwargs = {**lkwargs, "n_steps": self.n_steps, "epsilon": self.epsilon}
+        lkwargs = {**lkwargs, "proximal_step": self.proximal_step, "tau_diff": tau_diff}
+        lkwargs = {**lkwargs, "quadratic_weight": self.quadratic_weight}
+
+        @jax.jit
+        def jitted_update(params, opt_state, batch):
+            """A jitted update function."""
+            v, g = jax.value_and_grad(loss_fn)(params, batch, **lkwargs)
+            updates, opt_state = optimizer.update(g, opt_state, params)
+            return optax.apply_updates(params, updates), opt_state, v
+
+        @jax.jit
+        def jitted_validation(params, batch):
+            """A jitted validation function."""
+            return loss_fn(params, batch, **lkwargs)
+
+        # Initialize the parameters of the potential function and of the optimizer.
+        init_key, key = jax.random.split(key)
+        dummy_x = jnp.ones((batch_size, dataloader.n_features))  # Used to infer sizes.
+        self.params = self.potential.init(init_key, dummy_x)
+        opt_state = optimizer.init(self.params)
+
+        # Define the early stopping criterion and checkpointing parameters.
+        early_stop = EarlyStopping(min_delta=min_delta, patience=patience)
+
+        # The training loop.
+        pbar = tqdm(range(1, max_iter + 1))
+        for it in pbar:
+            # Choose whether to train or validate, weighted by train-val split.
+            batch_key, key = jax.random.split(key, num=2)
+            is_train = dataloader.train_or_val(it)
+
+            # If train, update the parameters. If val, just compute the loss.
+            if is_train:
+                self.params, opt_state, train_loss = jitted_update(
+                    self.params, opt_state, dataloader.next(batch_key, "train")
+                )
+                self.train_losses.append(train_loss)
+                self.train_it.append(it)
+            else:
+                next_batch = dataloader.next(batch_key, "val")
+                val_loss = jitted_validation(self.params, next_batch)
+                self.val_losses.append(val_loss)
+                self.val_it.append(it)
+
+            # Recap the statistics for the current iteration.
+            len_train, len_val = len(self.train_losses), len(self.val_losses)
+            iteration_stats = {
+                "iteration": it,
+                "train_loss": np.inf if len_train == 0 else train_loss,
+                "val_loss": np.inf if len_val == 0 else val_loss,
+            }
+
+            # Update the progress bar and log.
+            pbar.set_postfix(iteration_stats)
+            if self.log_callback:
+                self.log_callback(iteration_stats)
+
+            # Should we try early stopping and try to save the parameters?
+            # If we have validation set, this is done every validation batch.
+            # If we don't have validation set, this is done every train batch.
+            update_train = train_val_split == 1.0 and is_train
+            update_val = train_val_split < 1.0 and not is_train
+            if update_train or update_val:
+                # Check early stopping.
+                last_l = self.train_losses[-1] if update_train else self.val_losses[-1]
+                early_stop = early_stop.update(last_l)
+                if early_stop.should_stop:
+                    print("Met early stopping criteria, breaking...")
+                    break
+
+                # Try to save the parameters.
+                metrics = {"loss": np.float64(last_l)}
+                checkpoint_manager.save(
+                    it, args=StandardSave(self.params), metrics=metrics
+                )
+                checkpoint_manager.wait_until_finished()
+
+        if restore:
+            self.best_step = checkpoint_manager.best_step()
+            self.params = checkpoint_manager.restore(
+                self.best_step, args=StandardRestore(self.params)
+            )
+
+    def transform(
+        self,
+        adata: AnnData,
+        omics_key: str,
+        tau: float,
+        batch_size: int = 1_000,
+        key: Array = PRNGKey(0),
+    ) -> np.ndarray:
+        """Transform an AnnData object.
+
+        Args:
+            adata (AnnData): The AnnData object to transform.
+            omics_key (str): The obsm field containing the data to transform.
+            tau (float, optional): The time step.
+            batch_size (int, optional): The batch size. Defaults to 250.
+            key (jax.Array, optional): The random key. Defaults to PRNGKey(0).
+
+        Returns:
+            np.ndarray: The predictions.
+        """
+
+        # Define the potential function.
+        potential_fun = lambda u: self.potential.apply(self.params, u)
+
+        # Helper function to transform a batch.
+        def _transform_batch(idx_batch):
+            x = jnp.array(adata.obsm[omics_key][idx_batch])
+            a = jnp.ones(len(idx_batch)) / len(idx_batch)
+            return self.proximal_step.chained_inference_steps(
+                x, a, potential_fun, tau, self.n_steps
+            )
+
+        # Initizalize the prediction.
+        x_pred = np.zeros(adata.obsm[omics_key].shape)
+
+        # Iterate over batches and store the predictions.
+        idx = np.array(jax.random.permutation(key, jnp.arange(x_pred.shape[0])))
+        for idx_batch in np.array_split(idx, x_pred.shape[0] // batch_size):
+            x_pred[idx_batch] = np.array(_transform_batch(idx_batch))
+
+        # Return the predictions.
+        return x_pred

--- a/tools.py
+++ b/tools.py
@@ -1,0 +1,426 @@
+from typing import Dict
+
+from anndata import AnnData
+import jax
+from jax import Array
+from orbax.checkpoint import CheckpointManagerOptions, CheckpointManager
+import orbax.checkpoint as ocp
+import jax.numpy as jnp
+import numpy as np
+from dataclasses import dataclass
+import logging
+from sklearn.linear_model import LinearRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import SplineTransformer
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+from tqdm import tqdm
+from scipy.stats import ranksums
+
+
+@dataclass
+class DataLoader:
+    """DataLoader feeds data from an AnnData object to the model as JAX arrays. It
+    samples without replacement for a given batch size.
+
+    Args:
+        adata (AnnData): The input AnnData object.
+        time_key (str): The obs field with float time observations
+        omics_key (str): The obsm field with the omics coordinates.
+        space_key (str): The obsm field with the spatial coordinates.
+        batch_size (int): The batch size.
+        train_val_split (float, optional): The proportion of train in the split.
+        weight_key (str, optional): The obs field with the marginal weights.
+    """
+
+    adata: AnnData
+    time_key: str
+    omics_key: str
+    space_key: str
+    batch_size: int
+    train_val_split: float
+    weight_key: str | None = None
+
+    def __post_init__(self) -> None:
+        """Initialize the DataLoader."""
+
+        # Check that we have a valid time observation.
+        assert_msg = "Time observations must be numeric."
+        assert self.adata.obs[self.time_key].dtype.kind in "biuf", assert_msg
+
+        # If time is valid, then we can get hold of the timepoints and their indices.
+        self.timepoints = np.sort(np.unique(self.adata.obs[self.time_key]))
+        get_idx = lambda t: np.where(self.adata.obs[self.time_key] == t)[0]
+        self.idx = [get_idx(t) for t in self.timepoints]
+
+        # Get the number of features, spatial dimensions, and timepoints.
+        self.n_features = self.adata.obsm[self.omics_key].shape[1]
+        self.n_space = self.adata.obsm[self.space_key].shape[1]
+        self.n_timepoints = len(self.timepoints)
+
+    def make_train_val_split(self, key: Array) -> None:
+        """Make a train/validation split. Must be called before training.
+
+        Args:
+            key (PRNGKey): The random number generator key for permutations.
+        """
+
+        # Initialize the train and validation indices, from which we will sample batches.
+        self.idx_train, self.idx_val = [], []
+
+        # Iterate over timepoints.
+        for idx_t in self.idx:
+            # Permute the indices in order to make the split random.
+            key, key_permutation = jax.random.split(key)
+            permuted_idx = jax.random.permutation(key_permutation, idx_t)
+
+            # Split the indices between train and validation.
+            split = int(self.train_val_split * len(idx_t))
+            self.idx_train.append(permuted_idx[:split])
+            self.idx_val.append(permuted_idx[split:])
+
+        # Log some stats about the split.
+        logging.info(f"Train (# cells): {[len(idx) for idx in self.idx_train]}")
+        logging.info(f"Val (# cells): {[len(idx) for idx in self.idx_val]}")
+
+    def next(self, key: Array, train_or_val: str) -> Dict[str, jax.Array]:
+        """Get the next batch from either train or val indices.
+
+        Args:
+            key (jax.Array): The random number generator key for sampling.
+            train_or_val (str): Either "train" or "val".
+
+        Returns:
+            Dict[str, jax.Array]: A dictionary of JAX arrays.
+        """
+
+        # Check that we have a valid train or val argument.
+        assert train_or_val in ["train", "val"], "Select either 'train' or 'val'."
+        idx = self.idx_train if train_or_val == "train" else self.idx_val
+
+        # Initialize the lists of omics and spatial coordinates over timepoints.
+        x, space, a = [], [], []
+
+        # Iterate over timepoints.
+        for idx_t in idx:
+            key, key_choice = jax.random.split(key)
+            len_t = len(idx_t)
+
+            # if the batch size is smaller or equal to the number of cells n, then we
+            # want to sample a minibatch without replacement.
+            if self.batch_size <= len_t:
+                shape = (self.batch_size,)
+                batch_idx = jax.random.choice(key_choice, idx_t, shape, replace=False)
+
+                if self.weight_key:
+                    batch_a = self.adata.obs[self.weight_key].iloc[batch_idx].values
+                    batch_a /= batch_a.sum()
+                else:
+                    batch_a = np.ones(shape[0])
+                    batch_a /= batch_a.sum()  # Weights are uniform.
+
+            # if the batch size is greater than the number of cells n, then we want
+            # to pad the cells with random cells and pad a with zeroes.
+            else:
+                shape = (self.batch_size - len_t,)
+                batch_idx = jax.random.choice(key_choice, idx_t, shape, replace=True)
+                batch_idx = np.concatenate((idx_t, batch_idx))
+
+                if self.weight_key:
+                    batch_a = self.adata.obs[self.weight_key].iloc[idx_t].values
+                    batch_a = np.concatenate((batch_a, np.zeros(shape[0])))
+                    batch_a /= batch_a.sum()
+                else:
+                    batch_a = np.concatenate((np.ones(len_t), np.zeros(shape[0])))
+                    batch_a /= batch_a.sum()  # Weights are uniform.
+
+            # Get the omics and spatial coordinates for the batch.
+            x.append(self.adata.obsm[self.omics_key][batch_idx])
+            space.append(self.adata.obsm[self.space_key][batch_idx])
+            a.append(batch_a)
+
+        # Return a dictionary of JAX arrays, the first axis being time.
+        jnp_stack = lambda x: jnp.array(np.stack(x))
+        return {"x": jnp_stack(x), "space": jnp_stack(space), "a": jnp_stack(a)}
+
+    def train_or_val(self, iteration: int) -> bool:
+        """Sample whether to train or validate.
+
+        Args:
+            iteration (int): The current iteration.
+
+        Returns:
+            bool: True for train, False for val.
+        """
+        freq_val = 1 - self.train_val_split
+        return iteration % int(1 / freq_val) != 0
+
+
+def compute_potential(
+    adata: AnnData,
+    model,
+    omics_key: str,
+    key_added: str = "potential",
+) -> None:
+    """Compute the potential for all cells in an AnnData object.
+
+    Args:
+        adata (AnnData): Input data
+        model (SpaceTime): Trained model
+        omics_key (str): The omics key
+        key_added (str): The obs key to store the potential. Defaults to "potential"
+
+    """
+    potential_fn = lambda x: model.potential.apply(model.params, x)
+    adata.obs[key_added] = np.array(potential_fn(adata.obsm[omics_key]))
+
+
+def compute_velocity(
+    adata: AnnData,
+    model,
+    omics_key: str,
+    key_added: str = "X_velo",
+) -> None:
+    """Compute -grad J for all cells in an AnnData object, where J is the potential.
+
+    Args:
+        adata (AnnData): Input data
+        model (SpaceTime): Trained model
+        omics_key (str): The omics key
+        key_added (str): The obsm key to store the potential. Defaults to "X_velo"
+
+    """
+    potential_fn = lambda x: model.potential.apply(model.params, x)
+    velo_fn = lambda x: -jax.vmap(jax.grad(potential_fn))(x)
+    adata.obsm[key_added] = np.array(velo_fn(adata.obsm[omics_key]))
+
+
+def plot_velocity(
+    adata: AnnData,
+    omics_key: str,
+    basis: str,
+    velocity_key: str = "X_velo",
+    **kwargs,
+) -> None:
+    """Plot velocity, as computed by `compute_velocity`
+
+    Args:
+        adata (AnnData): Input data
+        omics_key (str): The obsm key for omics
+        velocity_key (str): The obsm key for the velocity
+    """
+    import cellrank as cr
+
+    vk = cr.kernels.VelocityKernel(
+        adata, attr="obsm", xkey=omics_key, vkey=velocity_key
+    ).compute_transition_matrix(backend="threading")
+    vk.plot_projection(basis=basis, recompute=True, **kwargs)
+
+
+def default_checkpoint_manager(absolute_path: str) -> CheckpointManager:
+    """Return a checkpoint manager
+
+    Args:
+        absolute_path (str): Checkpointing path
+    """
+    path = ocp.test_utils.erase_and_create_empty(absolute_path)
+    options = CheckpointManagerOptions(
+        save_interval_steps=1,
+        max_to_keep=1,
+        best_fn=lambda x: x["loss"],
+        best_mode="min",
+    )
+    return CheckpointManager(path / "checkpoints", options=options)
+
+
+def regress_genes(
+    adata, potential_key="potential", regression_model=None, key_added="regression"
+) -> None:
+
+    # We want to regress gene expression from the potential
+    x_train = np.array(adata.obs[potential_key]).reshape(-1, 1).astype(np.float64)
+
+    # The model is a spline regression
+    if not regression_model:
+        regression_model = make_pipeline(
+            SplineTransformer(knots="quantile", extrapolation="continue"),
+            LinearRegression(),
+        )
+
+    adata.layers[key_added] = adata.X.copy()
+
+    # Fit the regression_model for each gene and keep the score and argmax
+    for i, gene in tqdm(enumerate(adata.var_names)):
+
+        # The target gene expression
+        y_train = adata[:, gene].X.ravel()
+
+        # Fit the regression_model
+        regression_model.fit(x_train, y_train)
+
+        # Store the results
+        adata.layers[key_added][:, i] = regression_model.predict(x_train)
+        adata.var.loc[gene, key_added + "_score"] = regression_model.score(
+            x_train, y_train
+        )
+        adata.var.loc[gene, key_added + "_argmax"] = regression_model.predict(
+            np.sort(x_train, axis=0)
+        ).argmax()
+
+
+def select_driver_genes(
+    adata, n_stages: int, n_genes: int, regression_key="regression", remove_ones=True
+):
+
+    # By default, remove perfect score since they are suspect.
+    idx = np.array(adata.var[f"{regression_key}_score"]) != 1.0
+    adata_subset = adata[:, idx] if remove_ones else adata
+
+    i_list = np.arange(0, adata_subset.n_obs, adata_subset.n_obs // n_stages)
+
+    gene_names = []
+    for k in range(len(i_list) - 1):
+
+        # We'll look for the best genes in this interval
+        i_min, i_max = i_list[k], i_list[k + 1]
+        order_idx = i_min <= np.array(adata_subset.var[f"{regression_key}_argmax"])
+        order_idx &= np.array(adata_subset.var[f"{regression_key}_argmax"]) < i_max
+
+        for j, i in enumerate(
+            np.where(order_idx)[0][
+                np.argsort(
+                    np.array(adata_subset.var[f"{regression_key}_score"])[order_idx]
+                )[::-1][:n_genes]
+            ]
+        ):
+            gene_names.append(adata_subset.var_names[i])
+
+    return adata.var.loc[gene_names, f"{regression_key}_argmax"].sort_values().index
+
+
+def plot_gene_trends(
+    adata, gene_names, potential_key="potential", regression_key="regression", title=""
+):
+
+    fig, ax = plt.subplots(1, 1)
+
+    X = (
+        adata[np.argsort(np.array(adata.obs[potential_key])), gene_names]
+        .layers[regression_key]
+        .T.copy()
+    )
+
+    # Normalize rows
+    X = X - X.min(axis=1)[:, None]
+    X = X / X.max(axis=1)[:, None]
+    implot = ax.imshow(X, aspect="auto", cmap="viridis", interpolation="none")
+
+    # Set gene_names as yticks with small font size
+    ax.set_yticks(
+        np.arange(0, X.shape[0]),
+        gene_names,
+        fontsize=6,
+    )
+    ax.set_xlabel("Cells ordered by potential")
+
+    fig.colorbar(implot)
+    plt.title(title)
+
+    return fig, ax
+
+
+def plot_single_gene_trend(
+    adata,
+    gene,
+    potential_key="potential",
+    annotation_key="annotation",
+    regression_key="regression",
+    show_regression=False,
+    **kwargs,
+):
+
+    sns.scatterplot(
+        x=adata.obs[potential_key],
+        y=adata[:, gene].X.ravel(),
+        hue=adata.obs[annotation_key],
+        **kwargs,
+    )
+
+    if show_regression:
+        xx = adata.obs[potential_key]
+        yy = adata[:, gene].layers[regression_key].ravel()
+        sns.lineplot(x=xx, y=yy)
+
+    sns.despine()
+
+    plt.title(gene)
+    plt.legend(markerscale=3)
+    plt.show()
+
+
+def tf_enrich(adata, trrust_path, regression_key="regression", gene_key=None):
+    df_tf = pd.read_csv(trrust_path, sep="\t", header=None)
+    df_tf.columns = ["TF", "Target", "Mode", "References"]
+    if gene_key:
+        df_tf = df_tf[df_tf["Target"].isin(adata.var[gene_key].values)]
+    else:
+        df_tf = df_tf[df_tf["Target"].isin(adata.var_names)]
+
+    for tf in tqdm(df_tf["TF"].unique()):
+        idx = df_tf["TF"] == tf
+        adata.var[tf] = 0.0
+
+        # Iterate over rows of df_tf[idx]:
+        for target in df_tf.loc[idx, "Target"]:
+            if gene_key:
+                adata.var.loc[adata.var[gene_key].values == target, tf] = 1
+            else:
+                adata.var.loc[adata.var_names == target, tf] = 1
+
+    df_tf_stats = pd.DataFrame(index=df_tf["TF"].unique())
+    for tf in tqdm(df_tf_stats.index):
+
+        idx_target = adata.var[tf] > 0
+        target_scores = adata.var.loc[
+            idx_target, f"{regression_key}_score"
+        ].values.astype(float)
+
+        idx_nontarget = adata.var[tf] == 0
+        nontarget_scores = adata.var.loc[
+            idx_nontarget, f"{regression_key}_score"
+        ].values.astype(float)
+
+        stat, p_value = ranksums(target_scores, nontarget_scores, alternative="greater")
+        df_tf_stats.loc[tf, ["stat", "p_value", "n_targets"]] = (
+            stat,
+            p_value,
+            idx_target.sum(),
+        )
+
+    idx = df_tf_stats["p_value"] < 0.05
+    tf_names = df_tf_stats[idx].sort_values("p_value").index[:20]
+    sns.barplot(
+        y=tf_names.str.upper(), x=-np.log10(df_tf_stats.loc[tf_names, "p_value"])
+    )
+    plt.ylabel("Transcription factor")
+    plt.xlabel(r"$-\log_{10}(p)$")
+    plt.title("Transcription factor enrichment scores")
+    plt.show()
+
+
+def plot_losses(model):
+    plt.plot(model.train_it, model.train_losses, label="Train")
+    plt.plot(model.val_it, model.val_losses, label="Validation")
+    plt.plot(
+        model.best_step,
+        model.val_losses[np.where(np.array(model.val_it) == model.best_step)[0][0]],
+        "g*",
+        label="Retained iteration",
+    )
+    plt.ylabel("Loss")
+    plt.xlabel("Iteration")
+    plt.legend()
+    plt.yscale("log")
+    plt.show()


### PR DESCRIPTION
Hi,
continuing on the https://github.com/cantinilab/stories/issues/1 , I noticed that JAX has removed a while back the deprecated  `KeyArray `from `jax._src.random `. You can see the changelog here: https://github.com/jax-ml/jax/blob/main/CHANGELOG.md#jax-0424-feb-6-2024

Now using `jax.Array` as JAX changelog suggests.

Best Regards,
Marco Uderzo
